### PR TITLE
use `bun` instead of `deno`

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -12,7 +12,10 @@ get-debloated-pkgs --add-common --prefer-nano ffmpeg-mini
 
 echo "Building package and its dependencies..."
 echo "---------------------------------------------------------------"
-make-aur-package deno-stable-bin
+make-aur-package bun-bin
 make-aur-package python-emoji-country-flag
 make-aur-package aria2p
 make-aur-package varia
+
+# yt-dlp gives a warning that only deno is supported by default
+sed -i -e "s|default=\['deno'\]|default=['bun']|" /usr/lib/python*/site-packages/yt_dlp/options.py

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -12,6 +12,7 @@ get-debloated-pkgs --add-common --prefer-nano ffmpeg-mini
 
 echo "Building package and its dependencies..."
 echo "---------------------------------------------------------------"
+make-aur-package deno-stable-bin
 make-aur-package bun-bin
 make-aur-package python-emoji-country-flag
 make-aur-package aria2p
@@ -19,3 +20,4 @@ make-aur-package varia
 
 # yt-dlp gives a warning that only deno is supported by default
 sed -i -e "s|default=\['deno'\]|default=['bun']|" /usr/lib/python*/site-packages/yt_dlp/options.py
+pacman -Rdd --noconfirm deno-stable-bin

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -27,7 +27,7 @@ quick-sharun /usr/bin/varia \
              /usr/bin/aria2c \
              /usr/bin/aria2p \
              /usr/bin/yt-dlp \
-             /usr/bin/deno \
+             /usr/bin/bun \
              /usr/lib/libayatana* \
              /usr/share/gir-*/Ayatana* \
              /usr/lib/girepository-*/Ayatana* \


### PR DESCRIPTION
`yt-dlp` can use several other javascript runtimes

https://gitlab.archlinux.org/archlinux/packaging/packages/yt-dlp-ejs/-/work_items/3


It actually supports mquickjs, which is super tiny, the problem though it is that it is also a lot slower: https://github.com/pkgforge-dev/Anylinux-AppImages/issues/467#issuecomment-4189641177

So right now the best alternative is `bun`, it is faster than deno and smaller.

**deno also depends on userns so it should really be avoided always.** 


---


**NOTE:** I'm assuming the deno dependency is for `yt-dlp`, if it is needed by something else then this might break. 

